### PR TITLE
(Agrega): Saluda si un miembro se va

### DIFF
--- a/config/messages.js
+++ b/config/messages.js
@@ -3,6 +3,7 @@ const messages = {
     'seguirnos en twitter como [@ngVenezuela](https://twitter.com/ngVenezuela) ' +
     'y a mirar nuestra comunidad en Github: https://github.com/ngvenezuela.\n\n'+
     'Además nos gustaría que respondieras esta pequeña encuesta: http://bit.ly/ngve-encuesta',
+  goodbyeMsg: '¡Nos vemos pronto #{name}! Esperamos NO verte por el grupo de React Venezuela',
   goodMornings: {
     mondays: [
       'Buenos días comunidad, ¡Que tengan un excelente inicio de semana! \u{1F60E}',

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ let goodMorningGivenToday = false;
 let minuteToCheck = generateRandom(0, 59);
 
 bot
-  .on('new_chat_participant', newChatParticipant)
+  .on('new_chat_participant', sayHello)
+  .on('left_chat_participant', sayGoodbye)
   .on('text', newText);
 
 morningEvent
@@ -69,6 +70,11 @@ blogEvent
     });
   });
 
+function formatName(msgContext) {
+  return msgContext.username ?
+    '@' + msgContext.username : msgContext.first_name;
+}
+
 function newText(msg) {
   if (!goodMorningGivenToday && isGoodMorningGiven(msg.text)) {
     goodMorningGivenToday = true;
@@ -79,24 +85,20 @@ function newText(msg) {
   }
 }
 
-function newChatParticipant(msg) {
+function sayHello(msg) {
   bot.sendMessage(
     msg.chat.id,
-    getFullWelcomeMsg(msg),
+    messages.welcomeMsg.replace('#{name}', formatName(msg.new_chat_member)),
     {reply_to_message_id: msg.message_id, parse_mode: 'Markdown'}
   );
+}
 
-  function getFullWelcomeMsg(msg) {
-    let nameToBeShown = msg.new_chat_member.first_name;
-
-    if (msg.new_chat_member.username) {
-      nameToBeShown = '@' + msg.new_chat_member.username;
-    } else if (msg.new_chat_member.hasOwnProperty('last_name')) {
-      nameToBeShown = nameToBeShown + ' ' + msg.new_chat_member.last_name;
-    }
-
-    return messages.welcomeMsg.replace('#{name}', nameToBeShown);
-  }
+function sayGoodbye(msg) {
+  bot.sendMessage(
+    msg.chat.id,
+    messages.goodbyeMsg.replace('#{name}', formatName(msg.left_chat_member)),
+    {reply_to_message_id: msg.message_id, parse_mode: 'Markdown'}
+  );
 }
 
 bot.on('text', (msg) => {


### PR DESCRIPTION
Cuando un miembro del grupo se va, o es expulsado, @WengyBot lo hace saber en el grupo.

Relacionado a #51

**Estoy enviando un ...**  (marque con una "x")
```
[ ] Error reportado (Haz referencia al issue) => (Busca en github un issue o PR antés de enviar uno, NO olvides borrar esto).
[*] Solicitud de caracteristica (Haz referencia al issue, marcado como "Mejora", NO olvides borrar esto)

```

**Comportamiento Actual** 
De momento, el bot no hace nada cuando un miembro del grupo se va, o es expulsado.

**Comportamiento Esperado**
El bot coloca un mensaje en el grupo despidiendo a quien se va.

**Reproducción del Problema**
No aplica

**Cual es el motivo / Caso util para cambiar el comportamiento?**
Saber quien se va, como se discutió en #51 

**Por favor cuentamos sobre tu ambiente de desarrollo:**
No aplica
