### PR TITLE
(Modifica): Suscripciones externas de webhooks al server.

### DIFF
--- a/src/bot/telegram-bot.js
+++ b/src/bot/telegram-bot.js
@@ -1,0 +1,29 @@
+const NodeTelegramBotApi = require('node-telegram-bot-api');
+
+class TelegramBot extends NodeTelegramBotApi {
+
+  constructor(token, options = {}) {
+    super(token, options);
+  }
+
+  /**
+   * @return {boolean}
+   * @see https://core.telegram.org/bots/api#update
+   */
+  checkMessage(msg) {
+    return msg.message
+      || msg.edited_message
+      || msg.channel_post
+      || msg.edited_channel_post
+      || msg.inline_query
+      || msg.chosen_inline_result
+      || msg.callback_query;
+  }
+
+  proccessMessage(msg) {
+    this.processUpdate(msg);
+  }
+
+}
+
+module.exports = TelegramBot;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const TelegramBot = require('node-telegram-bot-api');
+const TelegramBot = require('./bot/telegram-bot');
 const BotServer = require('./server/bot-server');
 const telegramToken = require('./../config/config').telegramToken;
 const server = require('./../config/config').server;
@@ -14,7 +14,9 @@ const twitterEvent = require('./events/tweets');
 
 const bot = new TelegramBot(telegramToken);
 // eslint-disable-next-line no-unused-vars
-const botServer = new BotServer(bot, server.port);
+const botServer = new BotServer(`/${bot.token}`, server.port)
+ .subscribe(bot);
+
 let goodMorningGivenToday = false;
 let minuteToCheck = generateRandom(0, 59);
 


### PR DESCRIPTION
* Desacopla el server del bot.
* Añade método listen a clase Server que recibe un objeto con dos callbacks: `checkMessage(msg)` y `proccessMessage(msg)`.

Con esta refactorización ahora permite la subscripción de cualquier webhook al server, ya sea telegram, releases de github, pushfeedr, etc.