### PR TITLE
(Modifica): Envío de múltiples mensajes por item en releases de GitHub.

### DIFF
--- a/src/utils/github-release.js
+++ b/src/utils/github-release.js
@@ -10,23 +10,25 @@ const sendRelease = (bot, release, repository, changelogExist) => {
     return;
   }
 
-  const last = release.items[0];
   const name = repository.match(/[\w.-]+$/gi)[0];
-  const tag = last.id.match(/[\w.-]+$/gi)[0];
 
-  sendMessage(
-    bot,
-    config.groupId,
-    githubReleaseMessage
-      .replace('#{name}', name)
-      .replace('#{version}', tag)
-      .replace(
+  release.items.forEach(item => {
+    const tag = item.id.match(/[\w.-]+$/gi)[0];
+
+    sendMessage(
+      bot,
+      config.groupId,
+      githubReleaseMessage
+        .replace('#{name}', name)
+        .replace('#{version}', tag)
+        .replace(
         '#{url}',
         changelogExist
           ? `https://github.com/${repository}/blob/master/CHANGELOG.md`
           : `https://github.com/${repository}/releases/tag/${tag}`
-      )
-  );
+        )
+    );
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
**Estoy enviando un ...**  (marque con una "x")
```
[ ] Error reportado (Haz referencia al issue) => (Busca en github un issue o PR antés de enviar uno, NO olvides borrar esto).
[x] Solicitud de caracteristica (Haz referencia al issue, marcado como "Mejora", NO olvides borrar esto)

```

**Comportamiento Actual** 
En cada notificación de superfeedr, al enviar un mensaje de algún release en algún repo de github, solo toma en cuenta la versión más reciente.


**Comportamiento Esperado**
Si en el tiempo transcurrido desde la última notificación de superfeedr hubo más de un release se debería enviar al grupo n cantidad de mensajes como releases haya.

**Reproducción del Problema**
El equipo de Angular semanalmente libera una nueva versión.
A veces pueden ser dos, una versión estable, y otra que es beta. Para este caso Wengy notificará la versión más reciente.

**Cual es el motivo / Caso util para cambiar el comportamiento?**
_No aplica_


**Por favor cuentamos sobre tu ambiente de desarrollo:**
_No aplica_

